### PR TITLE
Remove <title> from manual article markup

### DIFF
--- a/templates/article.php
+++ b/templates/article.php
@@ -7,7 +7,6 @@
 <html lang="en" prefix="op: http://media.facebook.com/op#">
 <head>
 	<meta property="op:markup_version" content="v1.0">
-	<title><?php wp_title(); ?></title>
 	<link rel="canonical" href="<?php the_permalink(); ?>">
 </head>
 <body>


### PR DESCRIPTION
In testing - we tried copying the markup generated on the single article endpoint into the Facebook instant article publisher tool. It was picking up the page title from this title tag rather than the one included as part of the actual article markup.

Removing this ensures it picks up the correct title. 

Looking at the specs - it doesn't include `<title>` anywhere. See https://developers.facebook.com/docs/instant-articles/publishing#manual-create - so I don't think this is necessary.
