### PR TITLE
Fix article links in feed

### DIFF
--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -150,7 +150,7 @@ class Simple_FB_Instant_Articles {
 	}
 
 	public function rss_permalink( $link ) {
-		return esc_url( $link . $this->endpoint );
+		return trailingslashit( $link ) . $this->endpoint;
 	}
 
 }

--- a/templates/feed.php
+++ b/templates/feed.php
@@ -55,7 +55,7 @@ echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) )
 		<?php while ( $query->have_posts() ) : $query->the_post(); ?>
 			<item>
 				<title><?php esc_html( the_title_rss() ); ?></title>
-				<link><?php esc_url( the_permalink_rss() ); ?></link>
+				<link><?php the_permalink_rss(); ?></link>
 				<pubDate><?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_post_time( 'Y-m-d H:i:s', true ), false ) ); ?></pubDate>
 				<dc:creator><?php the_author(); ?></dc:creator>
 				<guid isPermaLink="false"><?php esc_html( the_guid() ); ?></guid>


### PR DESCRIPTION
In feed article link are missing the trailing slash before the FB endpoint.

Example:
/2015/11/03/some-article-slug

Should show link:
/2015/11/03/some-article-slug/fb-instant

Instead shows:
/2015/11/03/some-article-slugfb-instant
