### PR TITLE
Make params in instance() function optional, so that we can get class…

### DIFF
--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -32,7 +32,7 @@ class Simple_FB_Instant_Articles {
 	 *
 	 * @return Simple_FB_Instant_Articles
 	 */
-	public static function instance( $file, $version ) {
+	public static function instance( $file = null, $version = '' ) {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new self( $file, $version );
 		}


### PR DESCRIPTION
… instance in plugin code by Simple_FB_Instant_Articles::instance()
