### PR TITLE
Use main query for feed

### DIFF
--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -55,6 +55,7 @@ class Simple_FB_Instant_Articles {
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'init', array( $this, 'add_feed' ) );
 		add_action( 'wp', array( $this, 'add_actions' ) );
+		add_filter( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 		add_filter( 'simple_fb_before_feed', array( $this, 'update_rss_permalink' ) );
 
 		// Setup the props.
@@ -117,6 +118,26 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function add_feed() {
 		add_feed( $this->feed_slug, array( $this, 'feed_template' ) );
+	}
+
+	/**
+	 * Modify the query before getting any posts.
+	 *
+	 * @param  WP_Query $query WP Query object
+	 *
+	 * @return void
+	 */
+	public function pre_get_posts( WP_Query $query ) {
+
+		if ( $query->is_main_query() && $query->is_feed( $this->feed_slug ) ) {
+
+			$query->set( 'posts_per_rss', intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) ) );
+
+			// Allow easy access to modify query args for the FB IA feed.
+			do_action( 'simple_fb_pre_get_posts', $query );
+
+		}
+
 	}
 
 	/**

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -19,6 +19,8 @@ class Simple_FB_Instant_Articles {
 
 	/**
 	 * Feed Endpoint
+	 *
+	 * Use get_feed_slug to allow this to be filtered.
 	 */
 	private $feed_slug = 'fb';
 
@@ -65,9 +67,15 @@ class Simple_FB_Instant_Articles {
 		$this->template_path = trailingslashit( $this->dir ) . 'templates/';
 		$this->home_url = trailingslashit( home_url() );
 
-		// Set feed slug.
-		$this->feed_slug = apply_filters( 'simple_fb_feed_slug', $this->feed_slug );
+	}
 
+	/**
+	 * Get feed slug. Allow for filters.
+	 *
+	 * @return string
+	 */
+	public function get_feed_slug() {
+		return apply_filters( 'simple_fb_feed_slug', $this->feed_slug );
 	}
 
 	/**
@@ -123,7 +131,7 @@ class Simple_FB_Instant_Articles {
 	 * @return void
 	 */
 	public function add_feed() {
-		add_feed( $this->feed_slug, array( $this, 'feed_template' ) );
+		add_feed( $this->get_feed_slug(), array( $this, 'feed_template' ) );
 	}
 
 	/**
@@ -135,7 +143,7 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function pre_get_posts( WP_Query $query ) {
 
-		if ( $query->is_main_query() && $query->is_feed( $this->feed_slug ) ) {
+		if ( $query->is_main_query() && $query->is_feed( $this->get_feed_slug() ) ) {
 
 			$query->set( 'posts_per_rss', intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) ) );
 

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -108,8 +108,14 @@ class Simple_FB_Instant_Articles {
 	 * @return void
 	 */
 	public function render( $post_id ) {
+
 		do_action( 'simple_fb_pre_render', $post_id );
-		include( apply_filters( 'simple_fb_article_template_file', $this->template_path . '/article.php' ) );
+
+		if ( have_posts() ) {
+			the_post();
+			include( apply_filters( 'simple_fb_article_template_file', $this->template_path . '/article.php' ) );
+		}
+
 	}
 
 	/**

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -18,9 +18,9 @@ class Simple_FB_Instant_Articles {
 	private static $instance;
 
 	/**
-	 * Endpoint query var
+	 * Feed Endpoint
 	 */
-	private $token = 'fb';
+	private $feed_slug = 'fb';
 
 	/**
 	 * Endpoint query var
@@ -63,6 +63,10 @@ class Simple_FB_Instant_Articles {
 		$this->file = $file;
 		$this->template_path = trailingslashit( $this->dir ) . 'templates/';
 		$this->home_url = trailingslashit( home_url() );
+
+		// Set feed slug.
+		$this->feed_slug = apply_filters( 'simple_fb_feed_slug', $this->feed_slug );
+
 	}
 
 	/**
@@ -112,8 +116,7 @@ class Simple_FB_Instant_Articles {
 	 * @return void
 	 */
 	public function add_feed() {
-		$feed_slug = apply_filters( 'simple_fb_feed_slug', $this->token );
-		add_feed( $feed_slug, array( $this, 'feed_template' ) );
+		add_feed( $this->feed_slug, array( $this, 'feed_template' ) );
 	}
 
 	/**

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -18,11 +18,9 @@ class Simple_FB_Instant_Articles {
 	private static $instance;
 
 	/**
-	 * Feed Endpoint
-	 *
-	 * Use get_feed_slug to allow this to be filtered.
+	 * Endpoint query var
 	 */
-	private $feed_slug = 'fb';
+	private $token = 'fb';
 
 	/**
 	 * Endpoint query var
@@ -67,15 +65,6 @@ class Simple_FB_Instant_Articles {
 		$this->template_path = trailingslashit( $this->dir ) . 'templates/';
 		$this->home_url = trailingslashit( home_url() );
 
-	}
-
-	/**
-	 * Get feed slug. Allow for filters.
-	 *
-	 * @return string
-	 */
-	public function get_feed_slug() {
-		return apply_filters( 'simple_fb_feed_slug', $this->feed_slug );
 	}
 
 	/**
@@ -131,7 +120,8 @@ class Simple_FB_Instant_Articles {
 	 * @return void
 	 */
 	public function add_feed() {
-		add_feed( $this->get_feed_slug(), array( $this, 'feed_template' ) );
+		$feed_slug = apply_filters( 'simple_fb_feed_slug', $this->token );
+		add_feed( $feed_slug, array( $this, 'feed_template' ) );
 	}
 
 	/**
@@ -143,7 +133,9 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function pre_get_posts( WP_Query $query ) {
 
-		if ( $query->is_main_query() && $query->is_feed( $this->get_feed_slug() ) ) {
+		$feed_slug = apply_filters( 'simple_fb_feed_slug', $this->token );
+
+		if ( $query->is_main_query() && $query->is_feed( $feed_slug ) ) {
 
 			$query->set( 'posts_per_rss', intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) ) );
 

--- a/templates/article.php
+++ b/templates/article.php
@@ -10,10 +10,6 @@
 	<link rel="canonical" href="<?php the_permalink(); ?>">
 </head>
 <body>
-	<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
-		<?php include( 'content.php' ); ?>
-	<?php endwhile; else : ?>
-		<p><?php _e( 'Sorry, no posts matched your criteria.' ); ?></p>
-	<?php endif; ?>
+	<?php include( 'content.php' ); ?>
 </body>
 </html>

--- a/templates/feed.php
+++ b/templates/feed.php
@@ -31,28 +31,11 @@ echo '<?xml version="1.0" encoding="' . esc_attr( get_option( 'blog_charset' ) )
 	<description><?php echo esc_html( bloginfo( 'description' ) ); ?></description>
 	<lastBuildDate><?php echo esc_html( mysql2date( 'D, d M Y H:i:s +0000', get_lastpostmodified( 'GMT' ), false ) ); ?></lastBuildDate>
 	<language><?php echo esc_html( bloginfo( 'language' ) ); ?></language>
-	<?php
 
-	// Add RSS2 headers
-	do_action( 'rss2_head' );
+	<?php do_action( 'rss2_head' ); // Add RSS2 headers ?>
 
-	// How many posts? Let's add a specific filter for this.
-	$num_posts = intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) );
-
-	// And the default args.
-	$args = array(
-		'posts_per_page' => $num_posts,
-	);
-
-	// Add a filter for all of the args.
-	$args = apply_filters( 'simple_fb_feed_query_args', $args );
-
-	// Kick off the query.
-	$query = new WP_Query( $args );
-	?>
-
-	<?php if ( $query->have_posts() ) : ?>
-		<?php while ( $query->have_posts() ) : $query->the_post(); ?>
+	<?php if ( have_posts() ) : ?>
+		<?php while ( have_posts() ) : the_post(); ?>
 			<item>
 				<title><?php esc_html( the_title_rss() ); ?></title>
 				<link><?php esc_url( the_permalink_rss() ); ?></link>


### PR DESCRIPTION
The feed does not use the main query, instead doing a new WP_Query. I've refactored this a little bit to support the current functionality whilst making use of the main query.
- Instead of filtering query args, I've added an action: `simple_fb_pre_get_posts`. Simliar to pre_get_posts, but only called for the feed.
- I've removed the second loop from article. Its not necessary. For single articles we can do it in the template redirect method.
  - It no longer handles no posts, just shows nothing. As this is not intended for human consumption I think this is fine. (In fact I can't ever hit this - I just get a 404)

Other thoughts.

Not so keen on having to apply the filter a second time when I want to get the feed slug. Maybe a get method would be better?  Or another way of overriding this. Not a deal breaker.
