### PR TITLE
Handle oembeds

### DIFF
--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -56,8 +56,8 @@ class Simple_FB_Instant_Articles {
 		add_action( 'init', array( $this, 'add_feed' ) );
 		add_action( 'wp', array( $this, 'add_actions' ) );
 
-		add_action( 'simple_fb_before_feed', array( $this, 'content_modifications' ) );
-		add_action( 'simple_fb_pre_render', array( $this, 'content_modifications' ) );
+		add_action( 'simple_fb_before_feed', array( $this, 'pre_render' ) );
+		add_action( 'simple_fb_pre_render', array( $this, 'pre_render' ) );
 
 		// Setup the props.
 		$this->version = $version;
@@ -148,11 +148,11 @@ class Simple_FB_Instant_Articles {
 	}
 
 	/**
-	 * Modify content ready for FB IA.
+	 * Modify content before render ready for FB IA.
 	 *
 	 * @return void
 	 */
-	public function content_modifications() {
+	public function pre_render() {
 
 		add_filter( 'the_permalink_rss', array( $this, 'rss_permalink' ) );
 

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -55,7 +55,9 @@ class Simple_FB_Instant_Articles {
 		add_action( 'init', array( $this, 'init' ) );
 		add_action( 'init', array( $this, 'add_feed' ) );
 		add_action( 'wp', array( $this, 'add_actions' ) );
-		add_filter( 'simple_fb_before_feed', array( $this, 'update_rss_permalink' ) );
+
+		add_action( 'simple_fb_before_feed', array( $this, 'content_modifications' ) );
+		add_action( 'simple_fb_pre_render', array( $this, 'content_modifications' ) );
 
 		// Setup the props.
 		$this->version = $version;
@@ -145,12 +147,36 @@ class Simple_FB_Instant_Articles {
 		do_action( 'simple_fb_after_feed' );
 	}
 
-	public function update_rss_permalink() {
+	/**
+	 * Modify content ready for FB IA.
+	 *
+	 * @return void
+	 */
+	public function content_modifications() {
+
 		add_filter( 'the_permalink_rss', array( $this, 'rss_permalink' ) );
+
+		// Ensure oEmbeds are in the correct format.
+		add_filter( 'embed_handler_html', array( $this, 'format_social_embed' ) );
+		add_filter( 'embed_oembed_html', array( $this, 'format_social_embed' ) );
+
 	}
 
 	public function rss_permalink( $link ) {
 		return esc_url( $link . $this->endpoint );
+	}
+
+	/**
+	 * Ensure oEmbeds are in the correct format.
+	 *
+	 * Social embeds Ref: https://developers.facebook.com/docs/instant-articles/reference/social
+	 *
+	 * @param string   $html    HTML markup to be embeded into post sontent.
+	 *
+	 * @return string           HTML wrapped in FB IA markup for social embeds.
+	 */
+	public function format_social_embed( $html ) {
+		return '<figure class="op-social"><iframe>' . $html . '</iframe></figure>';
 	}
 
 }


### PR DESCRIPTION
Add support for oEmbed.

This is pretty simple and mostly seems to just work. There may be some edge cases with certain providers, but we can probably tackle those individually.

I've added a pre_render method to include all the stuff that needs to be hooked in, only within the FB IA  context, and added the RSS filter, as well as embed/oembed filters
