### PR TITLE
Add post styles via custom taxonomy.

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -20,3 +20,30 @@ function simple_fb_header_figure() {
 	$content = sprintf( '<figure>%s%s</figure>', get_the_post_thumbnail( get_the_id(), 'full' ), $caption );
 	return apply_filters( 'simple_fb_header_figure', $content );
 }
+
+/**
+ * Get a list of all style tags, and return them in the meta attribute.
+ * @return string
+ */
+function simple_fb_get_article_style() {
+	$post_id = get_the_id();
+	$terms   = get_the_terms( $post_id, 'style' );
+
+	// Do we have anything to work with here?
+	if ( ! empty( $terms ) ) {
+		// Build a string to hold everything.
+		$output = '';
+		// Loop through, and concatenate the terms
+		foreach ( $terms as $term ) {
+			$output .= $term->name . ' ';
+		}
+		// Return them all.
+		$output = rtrim( $output );
+	} else {
+		// Send the default
+		$output =  'default';
+	}
+
+	// Send them all out.
+	return apply_filters( 'simple_fb_post_styles', rtrim( $output ) );
+}

--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -9,6 +9,7 @@ Author URI: http://jakespurlock.com
 
 require_once( 'includes/functions.php' );
 require_once( 'includes/shortcodes.php' );
+require_once( 'taxonomies/style.php' );
 class Simple_FB_Instant_Articles {
 	/**
 	 * The one instance of Simple_FB_Instant_Articles.

--- a/taxonomies/style.php
+++ b/taxonomies/style.php
@@ -1,0 +1,39 @@
+<?php
+
+function style_init() {
+	register_taxonomy( 'style', array( 'post' ), array(
+		'hierarchical'      => true,
+		'public'            => true,
+		'show_in_nav_menus' => true,
+		'show_ui'           => true,
+		'show_admin_column' => false,
+		'query_var'         => true,
+		'rewrite'           => true,
+		'capabilities'      => array(
+			'manage_terms'  => 'edit_posts',
+			'edit_terms'    => 'edit_posts',
+			'delete_terms'  => 'edit_posts',
+			'assign_terms'  => 'edit_posts'
+		),
+		'labels'            => array(
+			'name'                       => __( 'Styles', 'simple-instant-articles-for-facebook' ),
+			'singular_name'              => _x( 'Style', 'taxonomy general name', 'simple-instant-articles-for-facebook' ),
+			'search_items'               => __( 'Search styles', 'simple-instant-articles-for-facebook' ),
+			'popular_items'              => __( 'Popular styles', 'simple-instant-articles-for-facebook' ),
+			'all_items'                  => __( 'All styles', 'simple-instant-articles-for-facebook' ),
+			'parent_item'                => __( 'Parent style', 'simple-instant-articles-for-facebook' ),
+			'parent_item_colon'          => __( 'Parent style:', 'simple-instant-articles-for-facebook' ),
+			'edit_item'                  => __( 'Edit style', 'simple-instant-articles-for-facebook' ),
+			'update_item'                => __( 'Update style', 'simple-instant-articles-for-facebook' ),
+			'add_new_item'               => __( 'New style', 'simple-instant-articles-for-facebook' ),
+			'new_item_name'              => __( 'New style', 'simple-instant-articles-for-facebook' ),
+			'separate_items_with_commas' => __( 'Styles separated by comma', 'simple-instant-articles-for-facebook' ),
+			'add_or_remove_items'        => __( 'Add or remove styles', 'simple-instant-articles-for-facebook' ),
+			'choose_from_most_used'      => __( 'Choose from the most used styles', 'simple-instant-articles-for-facebook' ),
+			'not_found'                  => __( 'No styles found.', 'simple-instant-articles-for-facebook' ),
+			'menu_name'                  => __( 'Styles', 'simple-instant-articles-for-facebook' ),
+		),
+	) );
+
+}
+add_action( 'init', 'style_init' );

--- a/templates/article.php
+++ b/templates/article.php
@@ -8,6 +8,7 @@
 <head>
 	<meta property="op:markup_version" content="v1.0">
 	<link rel="canonical" href="<?php the_permalink(); ?>">
+	<meta property="fb:article_style" content="<?php echo esc_attr( simple_fb_get_article_style() ); ?>">
 </head>
 <body>
 	<?php include( 'content.php' ); ?>


### PR DESCRIPTION
This goes hand in hand with https://github.com/whyisjake/Simple-Instant-Articles-for-Facebook/issues/4 where we want to be able the output for custom article styles. [FB says](https://developers.facebook.com/docs/instant-articles/guides/design) 

> "To apply a different style, change the title to match the preferred style name. Include any spaces if necessary, but upper or lowercase text doesn't matter:"

So, I think that we don't need to limit to just the first term, and looping through all would be fine.
