### PR TITLE
Order by last modified date

### DIFF
--- a/simple-fb-instant-articles.php
+++ b/simple-fb-instant-articles.php
@@ -140,6 +140,9 @@ class Simple_FB_Instant_Articles {
 
 			$query->set( 'posts_per_rss', intval( apply_filters( 'simple_fb_posts_per_rss', get_option( 'posts_per_rss', 10 ) ) ) );
 
+			// Orderby post modified date. Ensures updated posts get updated in FB IA.
+			$query->set( 'orderby', 'modified' );
+
 			// Allow easy access to modify query args for the FB IA feed.
 			do_action( 'simple_fb_pre_get_posts', $query );
 


### PR DESCRIPTION
To ensure that any post updates find there way into Facebook, the feed should be ordered by last modified date. This ensures they get updated even if they have dropped out of the latest posts shown in the feed by default.
