### PR TITLE
allow 'simple_fb_feed_slug' filter to return an array for multiple feeds

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -170,7 +170,16 @@ class Simple_FB_Instant_Articles {
 	 */
 	public function add_feed() {
 		$feed_slug = apply_filters( 'simple_fb_feed_slug', $this->token );
-		add_feed( $feed_slug, array( $this, 'feed_template' ) );
+
+		// register multiple feeds if simple_fb_feed_slug returns an array.
+		// feed queries can be differentiated via the customise_feed_query action
+		if (is_array($feed_slug)) {
+			foreach ($feed_slug as $slug) {
+				add_feed( $slug, array( $this, 'feed_template' ) );
+			}
+		} else {
+			add_feed( $feed_slug, array( $this, 'feed_template' ) );
+		}
 	}
 
 


### PR DESCRIPTION
We have separate FB pages for different verticals and so we'd like to have multiple feeds. This patch works really nicely in conjunction with modifying the query in the 'simple_fb_pre_get_posts' action based on which feed is being queried. query->is_feed already accepts an array, so the call in customise_feed_query doesn't need to be modified.