### PR TITLE
Filter image template

### DIFF
--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -391,8 +391,7 @@ class Simple_FB_Instant_Articles {
 			return '';
 		}
 
-		$template = trailingslashit( $this->template_path ) . 'image.php';
-		require( $template );
+		echo $this->render_template('image');
 	}
 
 	/**

--- a/simple-facebook-instant-articles.php
+++ b/simple-facebook-instant-articles.php
@@ -371,27 +371,27 @@ class Simple_FB_Instant_Articles {
 	/**
 	 * Outputs image markup in FB IA format.
 	 *
-	 * @param int|string $src     Image ID or source to output in FB IA format.
-	 * @param string     $caption Image caption to display in FB IA format.
+	 * @param int    $image_id Image ID or source to output in FB IA format.
+	 * @param string $caption  Image caption to display in FB IA format.
 	 */
 	public function render_image_markup( $image_id, $caption = '' ) {
 
-		global $fb_instant_image_id, $fb_instant_caption, $fb_instant_src;
-		$fb_instant_image_id = $image_id;
-		$fb_instant_caption  = $caption;
-
-		// Handle passing image ID.
-		if ( is_numeric( $image_id ) ) {
-			$image = wp_get_attachment_image_src( $image_id, $this->image_size );
-			$src   = $image ? $image[0] : null;
-			$fb_instant_src = $src;
+		if ( !is_numeric( $image_id ) ) {
+			return;
 		}
+
+		$image = wp_get_attachment_image_src( $image_id, $this->image_size );
+		$src   = $image ? $image[0] : null;
 
 		if ( empty( $src ) ) {
-			return '';
+			return;
 		}
 
-		echo $this->render_template('image');
+		echo $this->render_template('image', array(
+			'fb_instant_image_id' => $image_id,
+			'fb_instant_caption' => $caption,
+			'fb_instant_src' => $src
+		));
 	}
 
 	/**

--- a/templates/image.php
+++ b/templates/image.php
@@ -1,11 +1,10 @@
-<?php global $fb_instant_image_id, $fb_instant_caption, $fb_instant_src; ?>
 <figure data-feedback="fb:likes,fb:comments">
 
-	<img src="<?php echo esc_url( $fb_instant_src ); ?>" />
-	<?php $credit = get_post_meta( $fb_instant_image_id, '_credit', true ); ?>
-	<?php if ( ! empty( $fb_instant_caption ) || ! empty( $credit ) ) : ?>
+	<img src="<?php echo esc_url( $data['fb_instant_src'] ); ?>" />
+	<?php $credit = get_post_meta( $data['fb_instant_image_id'], '_credit', true ); ?>
+	<?php if ( ! empty( $data['fb_instant_caption'] ) || ! empty( $credit ) ) : ?>
 		<figcaption>
-			<?php ! empty( $fb_instant_caption ) ? printf( '<h1>%s</h1>', wp_strip_all_tags( $fb_instant_caption ) ) : ''; ?>
+			<?php ! empty( $data['fb_instant_caption'] ) ? printf( '<h1>%s</h1>', wp_strip_all_tags( $data['fb_instant_caption'] ) ) : ''; ?>
 			<?php ! empty( $credit ) ? printf( '<cite>%s</cite>', trim( esc_html( $credit ) ) ) : ''; ?>
 		</figcaption>
 	<?php endif; ?>


### PR DESCRIPTION
The image template file appears to be the only template filename that isn't filtered. This set of commits adds the filtering using the render_template method. It also modifies the image template to use the $data convention introduced by the render_template method instead of globals.